### PR TITLE
Fixed interviewer button redirect

### DIFF
--- a/frontend/src/components/dor/InterviewersDashboard/InterviewersTable.tsx
+++ b/frontend/src/components/dor/InterviewersDashboard/InterviewersTable.tsx
@@ -196,14 +196,14 @@ export default function InterviewersTable({
                     className="cursor-pointer"
                     onClick={() => {
                       navigate(
-                        "/admin/dor/applications/" +
+                        "/admin/dor/interviewer/" +
                           formId +
                           "/" +
                           row.original.interviewer.id,
                       );
                     }}
                   >
-                    View Applications
+                    View Interviewer
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>


### PR DESCRIPTION
Fixed the page that it goes to on Interviewer page when View Interviewer button is pressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Interviewers Table action to navigate to the interviewer detail page instead of applications.
  * Renamed the dropdown option from “View Applications” to “View Interviewer” for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->