### PR TITLE
add terra Thinking... screen

### DIFF
--- a/frontend/src/components/Loading.tsx
+++ b/frontend/src/components/Loading.tsx
@@ -74,7 +74,7 @@ export default function Loading() {
   return (
     <div className="min-h-96 w-full p-4 grow flex gap-3 flex-col items-center justify-center">
       <img
-        className="w-full max-w-54"
+        className="w-full max-w-56"
         src="/terra.png"
         alt="Terra Image"
       />

--- a/frontend/src/components/Loading.tsx
+++ b/frontend/src/components/Loading.tsx
@@ -1,12 +1,84 @@
+import { useEffect, useState } from "react";
+
+const MESSAGES = [
+  "Accomplishing",
+  "Actioning",
+  "Actualizing",
+  "Baking",
+  "Brewing",
+  "Calculating",
+  "Cerebrating",
+  "Churning",
+  "Terraing",
+  "Coalescing",
+  "Cogitating",
+  "Computing",
+  "Conjuring",
+  "Considering",
+  "Cooking",
+  "Crafting",
+  "Creating",
+  "Crunching",
+  "Deliberating",
+  "Determining",
+  "Doing",
+  "Effecting",
+  "Finagling",
+  "Forging",
+  "Forming",
+  "Generating",
+  "Hatching",
+  "Herding",
+  "Honking",
+  "Hustling",
+  "Ideating",
+  "Inferring",
+  "Manifesting",
+  "Marinating",
+  "Moseying",
+  "Mulling",
+  "Mustering",
+  "Musing",
+  "Noodling",
+  "Percolating",
+  "Pondering",
+  "Processing",
+  "Puttering",
+  "Reticulating",
+  "Ruminating",
+  "Schlepping",
+  "Shucking",
+  "Simmering",
+  "Smooshing",
+  "Spinning",
+  "Stewing",
+  "Synthesizing",
+  "Thinking",
+  "Transmuting",
+  "Vibing",
+  "Working",
+];
+
 export default function Loading() {
+  const [dots, setDots] = useState(1);
+  const [message] = useState(() => MESSAGES[Math.floor(Math.random() * MESSAGES.length)]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setDots((prevDots) => (prevDots % 3) + 1);
+    }, 750);
+
+    return () => clearInterval(interval);
+  }, []);
+
   return (
     <div className="min-h-96 w-full p-4 grow flex gap-3 flex-col items-center justify-center">
       <img
-        className="w-full max-w-72 animate-pulse"
-        src="/h4i_umd_logo.png"
-        alt="hack4impact-UMD"
+        className="w-full max-w-54"
+        src="/terra.png"
+        alt="Terra Image"
       />
-      <p className="text-center">Doing some important stuff, hold on...</p>
+      <p className="text-center">{message}{".".repeat(dots)}</p>
     </div>
   );
 }


### PR DESCRIPTION
Replaces loading screen with picture of Terra, and message with randomized synonym of "Thinking" and rotating dot count:

<img width="1919" height="939" alt="image" src="https://github.com/user-attachments/assets/a332fb1e-b7b3-4efd-8f45-923af9836bcd" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Loading screen now shows rotating, randomly selected messages with animated dot progress
  * Updated loading image and adjusted sizing/visual styling for a more polished experience during load times
<!-- end of auto-generated comment: release notes by coderabbit.ai -->