### PR TITLE
add cronjob for cleaning up stale autograder runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 CLAUDE.md
 /rubric
 .flame.json
+.vscode

--- a/backend/functions/src/index.ts
+++ b/backend/functions/src/index.ts
@@ -12,6 +12,7 @@ import * as admin from "firebase-admin";
 import { onRequest } from "firebase-functions/v2/https";
 
 import app from "./app";
+import { cleanupStaleJobsOnSchedule } from "./scheduled/cleanupStaleJobs";
 // import { uploadMockData } from "./utils/mockData";
 
 admin.initializeApp();
@@ -31,3 +32,5 @@ export const api = onRequest(
   { region: process.env.GCP_REGION || "us-east4" },
   app,
 );
+
+export { cleanupStaleJobsOnSchedule };

--- a/backend/functions/src/scheduled/cleanupStaleJobs.ts
+++ b/backend/functions/src/scheduled/cleanupStaleJobs.ts
@@ -9,7 +9,9 @@ import { appCollection } from "../utils/firestore";
 
 const STALE_TIMEOUT_MINUTES = 30;
 
-export async function cleanupStaleJobs() {
+// this is defined separately from the cronjob
+// in case we want to write a route for this logic
+async function cleanupStaleJobs() {
   const cutoffTime = Timestamp.fromMillis(
     Date.now() - STALE_TIMEOUT_MINUTES * 60 * 1000,
   );

--- a/backend/functions/src/scheduled/cleanupStaleJobs.ts
+++ b/backend/functions/src/scheduled/cleanupStaleJobs.ts
@@ -1,26 +1,33 @@
-import { onSchedule } from "firebase-functions/v2/scheduler";
-import { db } from "../index";
+import { FirestoreCollection } from "@app-portal/shared/constants";
+import { Timestamp } from "firebase-admin/firestore";
 import { logger } from "firebase-functions";
-import { CollectionReference, Timestamp } from "firebase-admin/firestore";
-import { GradingJobPublic, GradingJobStatus } from "../types/grading";
+import { onSchedule } from "firebase-functions/v2/scheduler";
 
-const GRADING_JOBS_PUBLIC_COLLECTION = "grading-jobs-public";
+import { db } from "../index";
+import { GradingJobStatus } from "../types/grading";
+import { appCollection } from "../utils/firestore";
+
 const STALE_TIMEOUT_MINUTES = 30;
 
 export async function cleanupStaleJobs() {
   const cutoffTime = Timestamp.fromMillis(
-    Date.now() - STALE_TIMEOUT_MINUTES * 60 * 1000
+    Date.now() - STALE_TIMEOUT_MINUTES * 60 * 1000,
   );
 
-  const publicGradingJobsCollection = db.collection(GRADING_JOBS_PUBLIC_COLLECTION) as CollectionReference<GradingJobPublic>;
+  const publicGradingJobsCollection = appCollection(
+    FirestoreCollection.GradingJobsPublic,
+  );
 
   const staleJobs = await publicGradingJobsCollection
     .where("updated", "<", cutoffTime)
-    .where("status", "not-in", [GradingJobStatus.Completed, GradingJobStatus.Failed])
-    .get(); 
+    .where("status", "not-in", [
+      GradingJobStatus.Completed,
+      GradingJobStatus.Failed,
+    ])
+    .get();
 
   if (staleJobs.empty) {
-    logger.info("No stale jobs found"); 
+    logger.info("No stale jobs found");
     return { cleanedCount: 0, totalStaleJobs: 0 };
   }
 
@@ -31,7 +38,7 @@ export async function cleanupStaleJobs() {
   staleJobs.docs.forEach((doc) => {
     const jobData = doc.data();
     const now = Timestamp.now();
-    
+
     batch.update(doc.ref, {
       status: GradingJobStatus.Failed,
       error: `Job timed out after ${STALE_TIMEOUT_MINUTES} minutes of inactivity. Last status: ${jobData.status}`,
@@ -40,7 +47,7 @@ export async function cleanupStaleJobs() {
     });
 
     logger.info(
-      `Marking job ${doc.id} as failed (was in status: ${jobData.status}, last updated: ${jobData.updated.toDate().toISOString()})`
+      `Marking job ${doc.id} as failed (was in status: ${jobData.status}, last updated: ${jobData.updated.toDate().toISOString()})`,
     );
   });
 
@@ -54,7 +61,7 @@ export async function cleanupStaleJobs() {
 
 export const cleanupStaleJobsOnSchedule = onSchedule(
   "*/10 * * * *",
-  async (event) => {
+  async () => {
     logger.info("Starting scheduled stale job cleanup...");
 
     try {
@@ -62,5 +69,5 @@ export const cleanupStaleJobsOnSchedule = onSchedule(
     } catch (error) {
       logger.error("Error during stale job cleanup:", error);
     }
-  }
+  },
 );

--- a/backend/functions/src/scheduled/cleanupStaleJobs.ts
+++ b/backend/functions/src/scheduled/cleanupStaleJobs.ts
@@ -1,0 +1,66 @@
+import { onSchedule } from "firebase-functions/v2/scheduler";
+import { db } from "../index";
+import { logger } from "firebase-functions";
+import { CollectionReference, Timestamp } from "firebase-admin/firestore";
+import { GradingJobPublic, GradingJobStatus } from "../types/grading";
+
+const GRADING_JOBS_PUBLIC_COLLECTION = "grading-jobs-public";
+const STALE_TIMEOUT_MINUTES = 30;
+
+export async function cleanupStaleJobs() {
+  const cutoffTime = Timestamp.fromMillis(
+    Date.now() - STALE_TIMEOUT_MINUTES * 60 * 1000
+  );
+
+  const publicGradingJobsCollection = db.collection(GRADING_JOBS_PUBLIC_COLLECTION) as CollectionReference<GradingJobPublic>;
+
+  const staleJobs = await publicGradingJobsCollection
+    .where("updated", "<", cutoffTime)
+    .where("status", "not-in", [GradingJobStatus.Completed, GradingJobStatus.Failed])
+    .get(); 
+
+  if (staleJobs.empty) {
+    logger.info("No stale jobs found"); 
+    return { cleanedCount: 0, totalStaleJobs: 0 };
+  }
+
+  logger.info(`Found ${staleJobs.size} stale jobs to clean up`);
+
+  const batch = db.batch();
+
+  staleJobs.docs.forEach((doc) => {
+    const jobData = doc.data();
+    const now = Timestamp.now();
+    
+    batch.update(doc.ref, {
+      status: GradingJobStatus.Failed,
+      error: `Job timed out after ${STALE_TIMEOUT_MINUTES} minutes of inactivity. Last status: ${jobData.status}`,
+      updated: now,
+      completed: now,
+    });
+
+    logger.info(
+      `Marking job ${doc.id} as failed (was in status: ${jobData.status}, last updated: ${jobData.updated.toDate().toISOString()})`
+    );
+  });
+
+  await batch.commit();
+  const cleanedCount = staleJobs.size;
+
+  logger.info(`Successfully cleaned up ${cleanedCount} stale jobs`);
+
+  return { cleanedCount, totalStaleJobs: cleanedCount };
+}
+
+export const cleanupStaleJobsOnSchedule = onSchedule(
+  "*/10 * * * *",
+  async (event) => {
+    logger.info("Starting scheduled stale job cleanup...");
+
+    try {
+      await cleanupStaleJobs();
+    } catch (error) {
+      logger.error("Error during stale job cleanup:", error);
+    }
+  }
+);

--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -1,4 +1,19 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "grading-jobs-public",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "updated",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automatic scheduled maintenance task that checks for grading jobs not updated for over 30 minutes and marks them as failed (instead of leaving them in progress indefinitely).
* **Performance**
  * Added a Firestore composite index to support the cleanup queries more efficiently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->