### PR TITLE
Add pre-commit hook for formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: local
+    hooks:
+      - id: format-frontend
+        name: Format frontend
+        entry: npx --prefix frontend prettier --write
+        language: system
+        files: ^frontend/
+
+      - id: format-backend-functions
+        name: Format backend functions
+        entry: npx --prefix backend/functions prettier --write
+        language: system
+        files: ^backend/functions/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,12 @@ repos:
     hooks:
       - id: format-frontend
         name: Format frontend
-        entry: npx --prefix frontend prettier --write
+        entry: npx --prefix frontend prettier --write --ignore-unknown
         language: system
         files: ^frontend/
 
       - id: format-backend-functions
         name: Format backend functions
-        entry: npx --prefix backend/functions prettier --write
+        entry: npx --prefix backend/functions prettier --write --ignore-unknown
         language: system
         files: ^backend/functions/

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ pip install pre-commit
 pre-commit install
 ```
 
-The hooks run `npm run format` in `frontend` and `backend/functions`.
+The hooks run Prettier on matching **staged files** in `frontend` and `backend/functions`.
+To format everything, run `pre-commit run --all-files` (or `npm run format` inside each package).
 
 ## 🖼️ Screenshots
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For instructions on setting up the Firebase emulators, see the [Firebase Emulato
     npm run serve
     ```
 
-## Formatting
+### Formatting
 
 This repository includes pre-commit hooks that format the frontend and backend
 functions before each commit. Enable by running:

--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ For instructions on setting up the Firebase emulators, see the [Firebase Emulato
     ```bash
     npm run serve
     ```
+
+## Formatting
+
+This repository includes pre-commit hooks that format the frontend and backend
+functions before each commit. Enable by running:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+The hooks run `npm run format` in `frontend` and `backend/functions`.
+
 ## 🖼️ Screenshots
 
 _Note: Some of these may be outdated_


### PR DESCRIPTION
Adds a [pre-commit](https://pre-commit.com/) config with local hooks for frontend and backend formatting. These hooks run before `git commit` and block the commit if Prettier reformats any staged files.

Pre-commit hooks need to be manually installed using `pre-commit install`. It can be a bit annoying to always have to pre-commit install whenever you enter new repos. I found it useful to add to my dotfiles an auto install script for any pre-commit hook in any repo I'm in.

Note this only applies for **staged** changes. If you want to apply the formatting to all files, you'd need to run
```shell
pre-commit run --all-files
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added local automated code-formatting hooks to run Prettier across frontend and backend function code, enabling consistent formatting in development and before commits.

* **Documentation**
  * Updated README with step-by-step instructions to enable and install the formatting hooks, activate the pre-commit integration, and run formatting across the repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->