### PR TITLE
objectLiteralTypeAssertions: "never"

### DIFF
--- a/backend/functions/eslint.config.mjs
+++ b/backend/functions/eslint.config.mjs
@@ -55,6 +55,13 @@ export default [
       "import/no-unresolved": 0,
       "object-curly-spacing": 0,
       eqeqeq: ["error", "always", { null: "ignore" }],
+      "@typescript-eslint/consistent-type-assertions": [
+        "error",
+        {
+          assertionStyle: "as",
+          objectLiteralTypeAssertions: "never",
+        },
+      ],
     },
   },
 ];

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -28,6 +28,13 @@ export default tseslint.config(
         { allowConstantExport: true },
       ],
       eqeqeq: ["error", "always", { null: "ignore" }],
+      "@typescript-eslint/consistent-type-assertions": [
+        "error",
+        {
+          assertionStyle: "as",
+          objectLiteralTypeAssertions: "never",
+        },
+      ],
     },
   },
 );

--- a/frontend/src/components/dor/QualifiedDashboard/QualifiedApplicationsTable.tsx
+++ b/frontend/src/components/dor/QualifiedDashboard/QualifiedApplicationsTable.tsx
@@ -6,7 +6,6 @@ import {
   ApplicantRole,
   ApplicationResponse,
   ReviewStatus,
-  InternalApplicationStatus,
   ReviewCapableUser,
 } from "@/types/types";
 import {
@@ -144,14 +143,14 @@ export default function QualifiedApplicationsTable({
 
       queryClient.setQueryData<QualifiedAppRow[]>(queryKey, (old) => {
         if (!old) return [];
-        return old.map((row: QualifiedAppRow) => {
+        return old.map((row: QualifiedAppRow): QualifiedAppRow => {
           if (row.status?.id === statusId) {
             return {
               ...row,
               status: {
                 ...row.status,
                 status: newStatus,
-              } as InternalApplicationStatus,
+              },
             };
           }
           return row;

--- a/frontend/src/pages/board/BoardAllApplicationsDashboard.tsx
+++ b/frontend/src/pages/board/BoardAllApplicationsDashboard.tsx
@@ -33,11 +33,10 @@ export default function BoardAllApplicationsPage() {
         ?.filter((app) => app.status !== ApplicationStatus.InProgress)
         ?.flatMap((app) =>
           app.rolesApplied.map(
-            (role) =>
-              ({
-                ...app,
-                rolesApplied: [role],
-              }) as ApplicationResponse,
+            (role): ApplicationResponse => ({
+              ...app,
+              rolesApplied: [role],
+            }),
           ),
         ),
     [apps],

--- a/frontend/src/pages/board/BoardInterviewsDashboard.tsx
+++ b/frontend/src/pages/board/BoardInterviewsDashboard.tsx
@@ -58,11 +58,10 @@ export default function BoardInterviewsDashboard() {
         ?.filter((app) => app.status !== ApplicationStatus.InProgress)
         ?.flatMap((app) =>
           app.rolesApplied.map(
-            (role) =>
-              ({
-                ...app,
-                rolesApplied: [role],
-              }) as ApplicationResponse,
+            (role): ApplicationResponse => ({
+              ...app,
+              rolesApplied: [role],
+            }),
           ),
         ) ?? [],
     [apps],

--- a/frontend/src/pages/super-reviewer/FormBuilderPage.tsx
+++ b/frontend/src/pages/super-reviewer/FormBuilderPage.tsx
@@ -23,7 +23,7 @@ import { Switch } from "@/components/ui/switch";
 import { AlertTriangleIcon } from "lucide-react";
 
 const decisionLetterVariants = ["accepted", "waitlist"] as const;
-const noop = () => { };
+const noop = () => {};
 const capitalize = (str: string) =>
   str.substring(0, 1).toUpperCase() + str.substring(1);
 
@@ -90,14 +90,14 @@ export default function FormBuilderPage() {
 
   const handleUploadForm = async () => {
     try {
-      const parsedForm = {
+      const parsedForm: ApplicationForm = {
         ...JSON.parse(jsonCode),
         id: formId ?? "",
-      } as ApplicationForm;
+      };
 
       const confirmed = window.confirm(
         `Are you sure you want to upload this application form?\n\n` +
-        `This will update the form with ID '${parsedForm.id}' in Firestore.`,
+          `This will update the form with ID '${parsedForm.id}' in Firestore.`,
       );
 
       if (!confirmed || !token) return;

--- a/frontend/src/pages/super-reviewer/dashboards/QualifiedApplicationsDashboard.tsx
+++ b/frontend/src/pages/super-reviewer/dashboards/QualifiedApplicationsDashboard.tsx
@@ -52,11 +52,10 @@ export default function QualifiedApplicationsDashboard() {
         ?.filter((app) => app.status !== ApplicationStatus.InProgress)
         ?.flatMap((app) =>
           app.rolesApplied.map(
-            (role) =>
-              ({
-                ...app,
-                rolesApplied: [role],
-              }) as ApplicationResponse,
+            (role): ApplicationResponse => ({
+              ...app,
+              rolesApplied: [role],
+            }),
           ),
         ) ?? [],
     [apps],

--- a/frontend/src/pages/super-reviewer/dashboards/UnderReviewDashboard.tsx
+++ b/frontend/src/pages/super-reviewer/dashboards/UnderReviewDashboard.tsx
@@ -33,11 +33,10 @@ export default function UnderReviewDashboard() {
         ?.filter((app) => app.status !== ApplicationStatus.InProgress)
         ?.flatMap((app) =>
           app.rolesApplied.map(
-            (role) =>
-              ({
-                ...app,
-                rolesApplied: [role],
-              }) as ApplicationResponse,
+            (role): ApplicationResponse => ({
+              ...app,
+              rolesApplied: [role],
+            }),
           ),
         ),
     [apps],

--- a/frontend/src/services/applicationFormsService.ts
+++ b/frontend/src/services/applicationFormsService.ts
@@ -87,9 +87,11 @@ export async function setFormDecisionRelease(
   ) as CollectionReference<ApplicationForm>;
   const docRef = doc(forms, formId);
 
-  await updateDoc(docRef, {
+  const update: Partial<ApplicationForm> = {
     decisionsReleased: released,
-  } as Partial<ApplicationForm>);
+  };
+
+  await updateDoc(docRef, update);
 }
 
 export async function setApplicationFormActiveStatus(
@@ -102,9 +104,11 @@ export async function setApplicationFormActiveStatus(
   ) as CollectionReference<ApplicationForm>;
   const docRef = doc(forms, formId);
 
-  await updateDoc(docRef, {
+  const update: Partial<ApplicationForm> = {
     isActive: active,
-  } as Partial<ApplicationForm>);
+  };
+
+  await updateDoc(docRef, update);
 }
 
 export async function setApplicationFormDueDate(formId: string, dueDate: Date) {
@@ -114,7 +118,9 @@ export async function setApplicationFormDueDate(formId: string, dueDate: Date) {
   ) as CollectionReference<ApplicationForm>;
   const docRef = doc(forms, formId);
 
-  await updateDoc(docRef, {
+  const update: Partial<ApplicationForm> = {
     dueDate: Timestamp.fromDate(dueDate),
-  } as Partial<ApplicationForm>);
+  };
+
+  await updateDoc(docRef, update);
 }

--- a/frontend/src/services/applicationResponsesService.ts
+++ b/frontend/src/services/applicationResponsesService.ts
@@ -14,6 +14,7 @@ import { API_URL, db } from "../config/firebase";
 import {
   ApplicationForm,
   ApplicationResponse,
+  ApplicationStatus,
   SectionResponse,
   ValidationError,
 } from "../types/types";
@@ -137,30 +138,31 @@ export async function fetchOrCreateApplicationResponse(
   }
   console.log("creating new response object!");
 
-  const sectionResponses: SectionResponse[] = form.sections.map((section) => ({
-    sectionId: section.sectionId,
-    sectionName: section.sectionName,
-    questions: section.questions.map((question) => ({
-      questionId: question.questionId,
-      questionType: question.questionType,
-      applicationFormId: form.id,
-      response:
-        question.questionType === "multiple-select" ||
-        question.questionType === "role-select"
-          ? []
-          : "",
-    })),
-  }));
+  const sectionResponses: SectionResponse[] = form.sections.map(
+    (section): SectionResponse => ({
+      sectionId: section.sectionId,
+      questions: section.questions.map((question) => ({
+        questionId: question.questionId,
+        questionType: question.questionType,
+        applicationFormId: form.id,
+        response:
+          question.questionType === "multiple-select" ||
+          question.questionType === "role-select"
+            ? []
+            : "",
+      })),
+    }),
+  );
 
-  const newResponse = {
+  const newResponse: ApplicationResponse = {
     id: uuidv4(),
     userId,
     applicationFormId: form.id,
     sectionResponses,
-    status: "in-progress",
+    status: ApplicationStatus.InProgress,
     dateSubmitted: Timestamp.now(),
     rolesApplied: [],
-  } as ApplicationResponse;
+  };
 
   console.log("new response:");
   console.log(newResponse);

--- a/frontend/src/services/boardService.ts
+++ b/frontend/src/services/boardService.ts
@@ -10,10 +10,11 @@ export async function getBoardMemberById(
 ): Promise<BoardUserProfile> {
   const user = await getUserById(id);
   if (user.role === PermissionRole.Board) {
-    return {
+    const boardUser: BoardUserProfile = {
       ...user,
       applicantRoles: user.applicantRoles ?? [],
-    } as BoardUserProfile;
+    };
+    return boardUser;
   } else {
     throw new Error("user is not a board member");
   }
@@ -37,10 +38,9 @@ export async function getAllBoardMembers(): Promise<BoardUserProfile[]> {
   return (await getDocs(q)).docs
     .map((d) => d.data() as BoardUserProfile)
     .map(
-      (b) =>
-        ({
-          ...b,
-          applicantRoles: b.applicantRoles ?? [],
-        }) as BoardUserProfile,
+      (b: BoardUserProfile): BoardUserProfile => ({
+        ...b,
+        applicantRoles: b.applicantRoles ?? [],
+      }),
     );
 }

--- a/frontend/src/services/statusService.ts
+++ b/frontend/src/services/statusService.ts
@@ -61,9 +61,11 @@ export async function rejectUndecidedApplicantsForForm(formId: string) {
     const batch = writeBatch(db);
 
     chunk.forEach((s) => {
-      batch.update(doc(statusCollection, s.id), {
+      const update: Partial<InternalApplicationStatus> = {
         status: ReviewStatus.Denied,
-      } as Partial<InternalApplicationStatus>);
+      };
+
+      batch.update(doc(statusCollection, s.id), update);
     });
 
     await batch.commit();

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -263,9 +263,11 @@ export async function setReviewerRolePreferences(
   const users = collection(db, USER_COLLECTION);
   const userDoc = doc(users, reviewerId);
 
-  await updateDoc(userDoc, {
+  const update: Partial<ReviewerUserProfile> = {
     applicantRolePreferences: prefs,
-  } as Partial<ReviewerUserProfile>);
+  };
+
+  await updateDoc(userDoc, update);
 }
 
 export async function setBoardApplicantRoles(
@@ -279,9 +281,11 @@ export async function setBoardApplicantRoles(
   const users = collection(db, USER_COLLECTION);
   const userDoc = doc(users, boardId);
 
-  await updateDoc(userDoc, {
+  const update: Partial<BoardUserProfile> = {
     applicantRoles: roles,
-  } as Partial<BoardUserProfile>);
+  };
+
+  await updateDoc(userDoc, update);
 }
 
 export function onAuthStateChange(


### PR DESCRIPTION
Add eslint rule to reject object type assertions. Part of project to improve codebase quality.

Type assertions are bad practice as they tell the compiler to ignore its own knowledge: https://typescript-eslint.io/rules/consistent-type-assertions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint configuration to enforce consistent type assertion patterns across the codebase.

* **Refactor**
  * Improved code quality by replacing implicit type conversions with explicit type annotations throughout the application, enhancing maintainability and type safety.
  * Refactored service functions to use typed update objects for database operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hack4Impact-UMD/app-portal/pull/126)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->