### PR TITLE
Centralized collection access + less type assertions

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -151,6 +151,25 @@
             "allowConstantExport": true,
           },
         ],
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "firebase/firestore",
+                "importNames": ["collection", "collectionGroup"],
+                "message": "Use the typed app Firestore helper instead.",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    // location of typed firestore helper on frontend
+    {
+      "files": ["frontend/src/services/firestore.ts"],
+      "rules": {
+        "no-restricted-imports": "off",
       },
     },
     {
@@ -164,6 +183,21 @@
         "import/no-named-as-default": "warn",
         "import/no-named-as-default-member": "warn",
         "import/no-duplicates": "warn",
+        "no-restricted-properties": [
+          "error",
+          {
+            "object": "db",
+            "property": "collection",
+            "message": "Use appCollection from utils/firestore instead.",
+          },
+        ],
+      },
+    },
+    // location of typed firestore helper on backend
+    {
+      "files": ["backend/functions/src/utils/firestore.ts"],
+      "rules": {
+        "no-restricted-properties": "off",
       },
     },
   ],

--- a/backend/functions/src/middleware/authentication.ts
+++ b/backend/functions/src/middleware/authentication.ts
@@ -1,11 +1,11 @@
+import { FirestoreCollection } from "@app-portal/shared/constants";
 import type { PermissionRole } from "@app-portal/shared/constants";
 import type { Request, Response, NextFunction } from "express";
 import * as admin from "firebase-admin";
-import type { CollectionReference } from "firebase-admin/firestore";
 import { logger } from "firebase-functions";
 
-import { db } from "..";
 import type { UserProfile } from "../models/user";
+import { appCollection } from "../utils/firestore";
 
 // from the code sample here: https://github.com/firebase/functions-samples/blob/main/Node-1st-gen/authorized-https-endpoint/functions/index.js
 // NOTE: When a request is successfully authenticated, this middleware will set the `req.token` property
@@ -108,9 +108,10 @@ export function hasRoles(roles: PermissionRole[]) {
 export async function getUserById(
   id: string,
 ): Promise<UserProfile | undefined> {
-  const users = db.collection("users") as CollectionReference<UserProfile>;
+  const users = appCollection(FirestoreCollection.Users);
   const userDoc = users.doc(id);
   const res = await userDoc.get();
 
-  return res.data() as UserProfile;
+  const user: UserProfile | undefined = res.data();
+  return user;
 }

--- a/backend/functions/src/routes/application.ts
+++ b/backend/functions/src/routes/application.ts
@@ -1,5 +1,6 @@
 import {
   ApplicationStatus,
+  FirestoreCollection,
   QuestionType,
   ReviewStatus,
   PermissionRole,
@@ -19,7 +20,6 @@ import {
 } from "@app-portal/shared/types";
 import type { Request, Response } from "express";
 import { Router } from "express";
-import type { CollectionReference } from "firebase-admin/firestore";
 import { Timestamp } from "firebase-admin/firestore";
 import { logger } from "firebase-functions";
 import { v4 as uuidv4 } from "uuid";
@@ -30,15 +30,10 @@ import { hasRoles, isAuthenticated } from "../middleware/authentication";
 import { validateSchema } from "../middleware/validation";
 import type { ApplicationForm } from "../models/appForm";
 import type { ApplicationResponse } from "../models/appResponse";
+import { appCollection } from "../utils/firestore";
 // import * as admin from "firebase-admin"
 
 const router = Router();
-
-const APPLICATION_RESPONSE_COLLECTION = "application-responses";
-const APPLICATION_FORMS_COLLECTION = "application-forms";
-const APPLICATION_STATUS_COLLECTION = "app-status";
-const RUBRICS_COLLECTION = "rubrics";
-const INTERVIEW_RUBRICS_COLLECTION = "interview-rubrics";
 
 interface QuestionMetadata {
   optional: boolean;
@@ -192,22 +187,27 @@ router.post(
       logger.info(`${req.token?.email} is submitting an application!`);
 
       // initialize connections to collections
-      const applicationResponseCollection = db.collection(
-        APPLICATION_RESPONSE_COLLECTION,
-      ) as CollectionReference<ApplicationResponse>;
-      const applicationFormCollection = db.collection(
-        APPLICATION_FORMS_COLLECTION,
-      ) as CollectionReference<ApplicationForm>;
-      const statusCollection = db.collection(
-        APPLICATION_STATUS_COLLECTION,
-      ) as CollectionReference<InternalApplicationStatus>;
+      const applicationResponseCollection = appCollection(
+        FirestoreCollection.ApplicationResponses,
+      );
+      const applicationFormCollection = appCollection(
+        FirestoreCollection.ApplicationForms,
+      );
+      const statusCollection = appCollection(
+        FirestoreCollection.ApplicationStatus,
+      );
 
       // check that the correct user is updating the application
       const applicationDoc = await applicationResponseCollection
         .doc(applicationResponse.id)
         .get();
-      const formattedApplicationDoc =
-        applicationDoc.data() as ApplicationResponse;
+      const formattedApplicationDoc: ApplicationResponse | undefined =
+        applicationDoc.data();
+      if (!formattedApplicationDoc) {
+        logger.warn(`Application response ${applicationResponse.id} not found`);
+        return res.status(404).send("Application response not found");
+      }
+
       if (formattedApplicationDoc.userId !== req.token?.uid) {
         return res
           .status(403)
@@ -218,10 +218,17 @@ router.post(
       const applicationFormDoc = await applicationFormCollection
         .doc(formattedApplicationDoc.applicationFormId)
         .get();
-      const applicationFormDocData = applicationFormDoc.data();
+      const applicationFormDocData: ApplicationForm | undefined =
+        applicationFormDoc.data();
+      if (!applicationFormDocData) {
+        logger.warn(
+          `Application form ${formattedApplicationDoc.applicationFormId} not found`,
+        );
+        return res.status(404).send("Application form not found");
+      }
 
       const currentTime = Timestamp.now();
-      const dueDate = applicationFormDocData!.dueDate;
+      const dueDate = applicationFormDocData.dueDate;
       if (currentTime > dueDate) {
         logger.warn(
           "Submission deadline passed for form:" + applicationFormDocData?.id,
@@ -326,12 +333,12 @@ router.put(
         return;
       }
 
-      const appCollection = db.collection(
-        APPLICATION_RESPONSE_COLLECTION,
-      ) as CollectionReference<ApplicationResponse>;
+      const applicationResponsesCollection = appCollection(
+        FirestoreCollection.ApplicationResponses,
+      );
 
-      const existingResp = (
-        await appCollection.doc(newAppResponse.id).get()
+      const existingResp: ApplicationResponse | undefined = (
+        await applicationResponsesCollection.doc(newAppResponse.id).get()
       ).data();
 
       if (!existingResp) {
@@ -352,7 +359,9 @@ router.put(
         return;
       }
 
-      await appCollection.doc(existingResp.id).set(newAppResponse);
+      await applicationResponsesCollection
+        .doc(existingResp.id)
+        .set(newAppResponse);
       logger.info(
         `Saved ApplicationResponse with ID: ${newAppResponse.id} for user ${newAppResponse.userId}`,
       );
@@ -374,12 +383,12 @@ router.post(
   async (req: Request, res: Response) => {
     try {
       const formData = req.body as ApplicationForm;
-      const formsCollection = db.collection(
-        APPLICATION_FORMS_COLLECTION,
-      ) as CollectionReference<ApplicationForm>;
-      const responsesCollection = db.collection(
-        APPLICATION_RESPONSE_COLLECTION,
-      ) as CollectionReference<ApplicationResponse>;
+      const formsCollection = appCollection(
+        FirestoreCollection.ApplicationForms,
+      );
+      const responsesCollection = appCollection(
+        FirestoreCollection.ApplicationResponses,
+      );
 
       const existingFormDoc = await formsCollection.doc(formData.id).get();
       const existingResponses =
@@ -390,7 +399,13 @@ router.post(
         ).docs.length > 0;
 
       if (existingFormDoc.exists && existingResponses) {
-        const existingForm = existingFormDoc.data() as ApplicationForm;
+        const existingForm: ApplicationForm | undefined =
+          existingFormDoc.data();
+        if (!existingForm) {
+          logger.warn(`Existing form ${formData.id} could not be retrieved`);
+          return res.status(400).send("Existing form could not be retrieved");
+        }
+
         const existingSectionIds = existingForm.sections.map(
           (s) => s.sectionId,
         );
@@ -501,14 +516,9 @@ router.post(
 
       const formId = [...formIds][0];
 
-      const rubricsCollection = db.collection(
-        RUBRICS_COLLECTION,
-      ) as CollectionReference<RoleReviewRubric>;
+      const rubricsCollection = appCollection(FirestoreCollection.Rubrics);
       const existingRubricsForForm = (
-        await db
-          .collection(RUBRICS_COLLECTION)
-          .where("formId", "==", formId)
-          .get()
+        await rubricsCollection.where("formId", "==", formId).get()
       ).docs;
 
       await db.runTransaction(async (transaction) => {
@@ -575,14 +585,11 @@ router.post(
 
       const formId = [...formIds][0];
 
-      const rubricsCollection = db.collection(
-        INTERVIEW_RUBRICS_COLLECTION,
-      ) as CollectionReference<RoleReviewRubric>;
+      const rubricsCollection = appCollection(
+        FirestoreCollection.InterviewRubrics,
+      );
       const existingRubricsForForm = (
-        await db
-          .collection(INTERVIEW_RUBRICS_COLLECTION)
-          .where("formId", "==", formId)
-          .get()
+        await rubricsCollection.where("formId", "==", formId).get()
       ).docs;
 
       await db.runTransaction(async (transaction) => {

--- a/backend/functions/src/routes/application.ts
+++ b/backend/functions/src/routes/application.ts
@@ -231,7 +231,7 @@ router.post(
       const dueDate = applicationFormDocData.dueDate;
       if (currentTime > dueDate) {
         logger.warn(
-          "Submission deadline passed for form:" + applicationFormDocData?.id,
+          "Submission deadline passed for form:" + applicationFormDocData.id,
         );
         return res.status(400).send("Submission deadline has passed");
       }
@@ -239,7 +239,7 @@ router.post(
       try {
         const errors = validateResponses(
           applicationResponse,
-          applicationFormDocData!,
+          applicationFormDocData,
         );
 
         if (errors.length !== 0) {

--- a/backend/functions/src/routes/auth.ts
+++ b/backend/functions/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import {
   ApplicationStatus,
+  FirestoreCollection,
   ReviewStatus,
   PermissionRole,
 } from "@app-portal/shared/constants";
@@ -18,10 +19,6 @@ import type { Request, Response } from "express";
 import { Router } from "express";
 import * as admin from "firebase-admin";
 import { FirebaseAuthError } from "firebase-admin/auth";
-import type {
-  CollectionReference,
-  DocumentReference,
-} from "firebase-admin/firestore";
 import { Timestamp } from "firebase-admin/firestore";
 import { logger } from "firebase-functions";
 import { v4 as uuidv4 } from "uuid";
@@ -29,9 +26,9 @@ import { v4 as uuidv4 } from "uuid";
 import { db } from "../index";
 import { isAuthenticated } from "../middleware/authentication";
 import { validateSchema } from "../middleware/validation";
-import type { ApplicationForm } from "../models/appForm";
 import type { ApplicationResponse } from "../models/appResponse";
 import type { UserProfile } from "../models/user";
+import { appCollection } from "../utils/firestore";
 
 /* eslint new-cap: 0 */
 const router = Router();
@@ -65,9 +62,7 @@ router.post(
 
       logger.info(`Auth user created with UID ${userRecord.uid}`);
 
-      const collection = db.collection(
-        "users",
-      ) as CollectionReference<UserProfile>;
+      const collection = appCollection(FirestoreCollection.Users);
 
       const user: UserProfile = {
         id: userRecord.uid,
@@ -116,9 +111,7 @@ router.post(
       );
 
       // will throw if doc doesn't exist
-      const userRef = db
-        .collection("users")
-        .doc(uid) as DocumentReference<UserProfile>;
+      const userRef = appCollection(FirestoreCollection.Users).doc(uid);
       await userRef.update({
         email: updateForm.email,
         firstName: updateForm.firstName,
@@ -159,9 +152,9 @@ router.post(
     const requestorUid = req.token!.uid;
 
     try {
-      const requestorRef = db
-        .collection("users")
-        .doc(requestorUid) as DocumentReference<UserProfile>;
+      const requestorRef = appCollection(FirestoreCollection.Users).doc(
+        requestorUid,
+      );
       const requestorSnap = await requestorRef.get();
       const requestor = requestorSnap.data();
 
@@ -171,9 +164,9 @@ router.post(
           .send("Only super-reviewers can create internal applicants");
       }
 
-      const formRef = db
-        .collection("application-forms")
-        .doc(requestData.formId) as DocumentReference<ApplicationForm>;
+      const formRef = appCollection(FirestoreCollection.ApplicationForms).doc(
+        requestData.formId,
+      );
       const formSnap = await formRef.get();
 
       if (!formSnap.exists || !formSnap.data()) {
@@ -186,9 +179,7 @@ router.post(
 
       // note: internal applicants are only given a user doc, not auth.
       // any other code where doc/auth are manipulated together must be updated.
-      const usersCollection = db.collection(
-        "users",
-      ) as CollectionReference<UserProfile>;
+      const usersCollection = appCollection(FirestoreCollection.Users);
       const userId = uuidv4();
 
       const batch = db.batch();
@@ -212,9 +203,9 @@ router.post(
         `created internal applicant ${newUser.firstName} ${newUser.lastName} with ID: ${newUser.id}`,
       );
 
-      const applicationResponsesCollection = db.collection(
-        "application-responses",
-      ) as CollectionReference<ApplicationResponse>;
+      const applicationResponsesCollection = appCollection(
+        FirestoreCollection.ApplicationResponses,
+      );
       const applicationResponseId = uuidv4();
 
       // internal applicants skip the review process
@@ -234,9 +225,9 @@ router.post(
         newApplicationResponse,
       );
 
-      const statusCollection = db.collection(
-        "app-status",
-      ) as CollectionReference<InternalApplicationStatus>;
+      const statusCollection = appCollection(
+        FirestoreCollection.ApplicationStatus,
+      );
 
       for (const role of requestData.rolesApplied) {
         const statusId = uuidv4();

--- a/backend/functions/src/routes/grading.ts
+++ b/backend/functions/src/routes/grading.ts
@@ -1,7 +1,9 @@
-import { PermissionRole } from "@app-portal/shared/constants";
+import {
+  FirestoreCollection,
+  PermissionRole,
+} from "@app-portal/shared/constants";
 import type { Response, Request } from "express";
 import { Router } from "express";
-import type { CollectionReference } from "firebase-admin/firestore";
 import { Timestamp } from "firebase-admin/firestore";
 import { logger } from "firebase-functions";
 import { v4 as uuidv4 } from "uuid";
@@ -14,19 +16,11 @@ import {
 } from "../middleware/authentication";
 import { validateSchema } from "../middleware/validation";
 import type { ApplicationResponse } from "../models/appResponse";
-import type {
-  GradingJobPublic,
-  GradingJobDataInternal,
-} from "../types/grading";
 import { submitGradingJobSchema, GradingJobStatus } from "../types/grading";
 import { publishGradingTask } from "../utils/cloudTasks";
+import { appCollection } from "../utils/firestore";
 
 const router = Router();
-
-// TODO: we should have a centralized file for importing these to avoid duplication
-const GRADING_JOBS_PUBLIC_COLLECTION = "grading-jobs-public";
-const GRADING_JOBS_INTERNAL_COLLECTION = "grading-jobs-internal";
-const APPLICATION_RESPONSES_COLLECTION = "application-responses";
 
 router.post(
   "/submit",
@@ -51,15 +45,15 @@ router.post(
 
       logger.info(`Received autograder request for responseId ${responseId}`);
 
-      const applicationResponseCollection = db.collection(
-        APPLICATION_RESPONSES_COLLECTION,
-      ) as CollectionReference<ApplicationResponse>;
-      const gradingJobsPublicCollection = db.collection(
-        GRADING_JOBS_PUBLIC_COLLECTION,
-      ) as CollectionReference<GradingJobPublic>;
-      const gradingJobsInternalCollection = db.collection(
-        GRADING_JOBS_INTERNAL_COLLECTION,
-      ) as CollectionReference<GradingJobDataInternal>;
+      const applicationResponseCollection = appCollection(
+        FirestoreCollection.ApplicationResponses,
+      );
+      const gradingJobsPublicCollection = appCollection(
+        FirestoreCollection.GradingJobsPublic,
+      );
+      const gradingJobsInternalCollection = appCollection(
+        FirestoreCollection.GradingJobsInternal,
+      );
 
       const responseDoc = await applicationResponseCollection
         .doc(responseId)
@@ -70,9 +64,15 @@ router.post(
         return res.status(404).send("Application response not found");
       }
 
-      const responseData = responseDoc.data() as ApplicationResponse;
+      const responseData: ApplicationResponse | undefined = responseDoc.data();
+      if (!responseData) {
+        logger.warn(
+          `Attempted to retrieve response with id: ${responseId} unsuccessfully`,
+        );
+        return res.status(404).send("Application response not found");
+      }
 
-      const isOwner = responseData?.userId === userId;
+      const isOwner = responseData.userId === userId;
       const isAdmin = [
         PermissionRole.Board,
         PermissionRole.SuperReviewer,

--- a/backend/functions/src/routes/status.ts
+++ b/backend/functions/src/routes/status.ts
@@ -21,11 +21,7 @@ async function decisionsReleased(formId: string) {
   const form: ApplicationForm | undefined = (
     await appCollection(FirestoreCollection.ApplicationForms).doc(formId).get()
   ).data();
-  if (!form) {
-    logger.warn(`Application form ${formId} not found`);
-    throw new Error("Form not found!");
-  }
-  return form.decisionsReleased;
+  return form?.decisionsReleased;
 }
 
 router.get(
@@ -69,7 +65,16 @@ router.get(
       return;
     }
 
-    if (await decisionsReleased(responseDoc.applicationFormId)) {
+    const released = await decisionsReleased(responseDoc.applicationFormId);
+    if (released === undefined) {
+      logger.warn(
+        `Application form ${responseDoc.applicationFormId} not found`,
+      );
+      res.status(404).json({ error: "Form not found" });
+      return;
+    }
+
+    if (released) {
       res.json({
         id: status.docs[0].id,
         status: data.status,

--- a/backend/functions/src/routes/status.ts
+++ b/backend/functions/src/routes/status.ts
@@ -1,31 +1,30 @@
-import { ReviewStatus, PermissionRole } from "@app-portal/shared/constants";
+import {
+  FirestoreCollection,
+  ReviewStatus,
+  PermissionRole,
+} from "@app-portal/shared/constants";
 import { DecisionConfirmationSchema } from "@app-portal/shared/types";
-import type {
-  DecisionConfirmation,
-  InternalApplicationStatus,
-} from "@app-portal/shared/types";
+import type { DecisionConfirmation } from "@app-portal/shared/types";
 import type { Request, Response } from "express";
 import { Router } from "express";
-import type { CollectionReference } from "firebase-admin/firestore";
 import { logger } from "firebase-functions";
 
-import { db } from "..";
 import { hasRoles, isAuthenticated } from "../middleware/authentication";
 import { validateSchema } from "../middleware/validation";
 import type { ApplicationForm } from "../models/appForm";
 import type { ApplicationResponse } from "../models/appResponse";
+import { appCollection } from "../utils/firestore";
 
 const router = Router();
-const APPLICATION_STATUS_COLLECTION = "app-status";
-const APPLICATION_FORMS_COLLECTION = "application-forms";
-const APPLICATION_RESPONSE_COLLECTION = "application-responses";
-const DECISION_STATUS_COLLECTION = "decision-status";
 
 async function decisionsReleased(formId: string) {
-  const form = (
-    await db.collection(APPLICATION_FORMS_COLLECTION).doc(formId).get()
-  ).data() as ApplicationForm;
-  if (!form) throw new Error(`Form ${formId} not found!`);
+  const form: ApplicationForm | undefined = (
+    await appCollection(FirestoreCollection.ApplicationForms).doc(formId).get()
+  ).data();
+  if (!form) {
+    logger.warn(`Application form ${formId} not found`);
+    throw new Error("Form not found!");
+  }
   return form.decisionsReleased;
 }
 
@@ -36,11 +35,14 @@ router.get(
     const response = req.params.responseId as string;
     const role = req.params.role as string;
 
-    const responseDoc = (
-      await db.collection(APPLICATION_RESPONSE_COLLECTION).doc(response).get()
-    ).data() as ApplicationResponse;
+    const responseDoc: ApplicationResponse | undefined = (
+      await appCollection(FirestoreCollection.ApplicationResponses)
+        .doc(response)
+        .get()
+    ).data();
 
     if (!responseDoc) {
+      logger.warn(`Application response ${response} not found`);
       res.status(404).send();
       return;
     }
@@ -50,9 +52,9 @@ router.get(
       return;
     }
 
-    const statusCollection = db.collection(
-      APPLICATION_STATUS_COLLECTION,
-    ) as CollectionReference<InternalApplicationStatus>;
+    const statusCollection = appCollection(
+      FirestoreCollection.ApplicationStatus,
+    );
     const status = await statusCollection
       .where("role", "==", role)
       .where("responseId", "==", response)
@@ -60,6 +62,9 @@ router.get(
 
     const data = status.docs[0]?.data() ?? undefined;
     if (!data) {
+      logger.warn(
+        `Application status not found for response ${response} and role ${role}`,
+      );
       res.status(404).send();
       return;
     }
@@ -109,9 +114,9 @@ router.post(
     try {
       console.log("Request received:", req.body); // Log the incoming request body
 
-      const decisionStatusCollection = db.collection(
-        DECISION_STATUS_COLLECTION,
-      ) as CollectionReference<DecisionConfirmation>;
+      const decisionStatusCollection = appCollection(
+        FirestoreCollection.DecisionStatus,
+      );
 
       const input = req.body as DecisionConfirmation;
       const { responseId, userId, internalStatusId } = input;
@@ -139,9 +144,9 @@ router.post(
       }
 
       // Look up applicant’s internal decision in app-status
-      const statusCollection = db.collection(
-        APPLICATION_STATUS_COLLECTION,
-      ) as CollectionReference<InternalApplicationStatus>;
+      const statusCollection = appCollection(
+        FirestoreCollection.ApplicationStatus,
+      );
       const statusDocs = await statusCollection
         .where("id", "==", internalStatusId)
         .get();

--- a/backend/functions/src/utils/firestore.ts
+++ b/backend/functions/src/utils/firestore.ts
@@ -1,0 +1,40 @@
+import type { FirestoreCollection } from "@app-portal/shared/constants";
+import type {
+  ApplicationInterviewData,
+  ApplicationReviewData,
+  AppReviewAssignment,
+  DecisionConfirmation,
+  InternalApplicationStatus,
+  InterviewAssignment,
+  RoleReviewRubric,
+} from "@app-portal/shared/types";
+import type { CollectionReference } from "firebase-admin/firestore";
+
+import { db } from "..";
+import type { ApplicationForm } from "../models/appForm";
+import type { ApplicationResponse } from "../models/appResponse";
+import type { UserProfile } from "../models/user";
+import type {
+  GradingJobDataInternal,
+  GradingJobPublic,
+} from "../types/grading";
+
+type ServerCollectionData = {
+  [FirestoreCollection.Users]: UserProfile;
+  [FirestoreCollection.ApplicationForms]: ApplicationForm;
+  [FirestoreCollection.ApplicationResponses]: ApplicationResponse;
+  [FirestoreCollection.ApplicationStatus]: InternalApplicationStatus;
+  [FirestoreCollection.DecisionStatus]: DecisionConfirmation;
+  [FirestoreCollection.Rubrics]: RoleReviewRubric;
+  [FirestoreCollection.InterviewRubrics]: RoleReviewRubric;
+  [FirestoreCollection.ReviewData]: ApplicationReviewData;
+  [FirestoreCollection.InterviewData]: ApplicationInterviewData;
+  [FirestoreCollection.ReviewAssignments]: AppReviewAssignment;
+  [FirestoreCollection.InterviewAssignments]: InterviewAssignment;
+  [FirestoreCollection.GradingJobsPublic]: GradingJobPublic;
+  [FirestoreCollection.GradingJobsInternal]: GradingJobDataInternal;
+};
+
+export function appCollection<C extends keyof ServerCollectionData>(name: C) {
+  return db.collection(name) as CollectionReference<ServerCollectionData[C]>;
+}

--- a/frontend/src/services/applicationFormsService.ts
+++ b/frontend/src/services/applicationFormsService.ts
@@ -1,34 +1,32 @@
+import { FirestoreCollection } from "@app-portal/shared/constants";
 import axios from "axios";
-import type { CollectionReference } from "firebase/firestore";
 import {
-  collection,
   doc,
   getDoc,
   getDocs,
+  query,
   Timestamp,
   updateDoc,
   where,
 } from "firebase/firestore";
-import { query } from "firebase/firestore";
 
-import { db, API_URL } from "@/config/firebase";
+import { API_URL } from "@/config/firebase";
 import type { ApplicationForm } from "@/types/types";
 
 import { getAppCheckToken } from "./appCheckService";
 import { getApplicationResponseById } from "./applicationResponsesService";
-
-const APPLICATION_FORMS_COLLECTION = "application-forms";
+import { appCollection } from "./firestore";
 
 export async function getApplicationForm(
   formId: string,
 ): Promise<ApplicationForm> {
-  const forms = collection(db, APPLICATION_FORMS_COLLECTION);
+  const forms = appCollection(FirestoreCollection.ApplicationForms);
   const form = await getDoc(doc(forms, formId));
 
   if (!form.exists())
     throw new Error(`Application form with ID ${formId} does not exist`);
 
-  return form.data() as ApplicationForm;
+  return form.data();
 }
 
 export async function getApplicationFormForResponseId(
@@ -43,24 +41,24 @@ export async function getApplicationFormForResponseId(
 }
 
 export async function getAllForms(): Promise<ApplicationForm[]> {
-  const formsRef = collection(db, APPLICATION_FORMS_COLLECTION);
+  const formsRef = appCollection(FirestoreCollection.ApplicationForms);
   const snapshot = await getDocs(formsRef);
 
   const forms: ApplicationForm[] = snapshot.docs.map((doc) => ({
     ...doc.data(),
     id: doc.id,
-  })) as ApplicationForm[];
+  }));
 
   return forms;
 }
 
 export async function getActiveForm(): Promise<ApplicationForm> {
-  const forms = collection(db, APPLICATION_FORMS_COLLECTION);
+  const forms = appCollection(FirestoreCollection.ApplicationForms);
   const q = query(forms, where("isActive", "==", true));
 
   const docs = (await getDocs(q)).docs.map((d) => d.data());
   console.log(docs);
-  if (docs.length > 0) return docs[0] as ApplicationForm;
+  if (docs.length > 0) return docs[0];
   else {
     throw new Error("No active form!");
   }
@@ -83,10 +81,7 @@ export async function setFormDecisionRelease(
   formId: string,
   released: boolean,
 ) {
-  const forms = collection(
-    db,
-    APPLICATION_FORMS_COLLECTION,
-  ) as CollectionReference<ApplicationForm>;
+  const forms = appCollection(FirestoreCollection.ApplicationForms);
   const docRef = doc(forms, formId);
 
   const update: Partial<ApplicationForm> = {
@@ -100,10 +95,7 @@ export async function setApplicationFormActiveStatus(
   formId: string,
   active: boolean,
 ) {
-  const forms = collection(
-    db,
-    APPLICATION_FORMS_COLLECTION,
-  ) as CollectionReference<ApplicationForm>;
+  const forms = appCollection(FirestoreCollection.ApplicationForms);
   const docRef = doc(forms, formId);
 
   const update: Partial<ApplicationForm> = {
@@ -114,10 +106,7 @@ export async function setApplicationFormActiveStatus(
 }
 
 export async function setApplicationFormDueDate(formId: string, dueDate: Date) {
-  const forms = collection(
-    db,
-    APPLICATION_FORMS_COLLECTION,
-  ) as CollectionReference<ApplicationForm>;
+  const forms = appCollection(FirestoreCollection.ApplicationForms);
   const docRef = doc(forms, formId);
 
   const update: Partial<ApplicationForm> = {

--- a/frontend/src/services/applicationResponseAndSemesterService.ts
+++ b/frontend/src/services/applicationResponseAndSemesterService.ts
@@ -1,12 +1,10 @@
-import type { CollectionReference } from "firebase/firestore";
-import { collection, getDocs, query, where } from "firebase/firestore";
+import { FirestoreCollection } from "@app-portal/shared/constants";
+import { getDocs, query, where } from "firebase/firestore";
 
-import { db } from "@/config/firebase";
-import type { ApplicationForm, ApplicationResponse } from "@/types/types";
+import type { ApplicationResponse } from "@/types/types";
 
 import { getApplicationResponses } from "./applicationResponsesService";
-
-const APPLICATION_FORMS_COLLECTION = "application-forms";
+import { appCollection } from "./firestore";
 
 export type ApplicationResponseWithSemester = ApplicationResponse & {
   semester: string;
@@ -16,10 +14,7 @@ export type ApplicationResponseWithSemester = ApplicationResponse & {
 export async function getApplicationResponseAndSemester(
   userId: string,
 ): Promise<ApplicationResponseWithSemester[]> {
-  const forms = collection(
-    db,
-    APPLICATION_FORMS_COLLECTION,
-  ) as CollectionReference<ApplicationForm>;
+  const forms = appCollection(FirestoreCollection.ApplicationForms);
 
   const rawResponses = await getApplicationResponses(userId);
   const responsesWithSemester: ApplicationResponseWithSemester[] = [];
@@ -30,9 +25,7 @@ export async function getApplicationResponseAndSemester(
       where("id", "==", response.applicationFormId),
     );
     const formResults = await getDocs(formQuery);
-    const matchedForms = formResults.docs.map(
-      (d) => d.data() as ApplicationForm,
-    );
+    const matchedForms = formResults.docs.map((d) => d.data());
 
     const form = matchedForms.length > 0 ? matchedForms[0] : undefined;
     const semester = form?.semester ?? "Unknown";

--- a/frontend/src/services/applicationResponsesService.ts
+++ b/frontend/src/services/applicationResponsesService.ts
@@ -1,4 +1,8 @@
-import { ApplicationStatus, QuestionType } from "@app-portal/shared/constants";
+import {
+  ApplicationStatus,
+  FirestoreCollection,
+  QuestionType,
+} from "@app-portal/shared/constants";
 import type {
   SectionResponse,
   ValidationError,
@@ -8,7 +12,6 @@ import {
   setDoc,
   Timestamp,
   arrayUnion,
-  collection,
   doc,
   getDocs,
   query,
@@ -18,12 +21,11 @@ import {
 } from "firebase/firestore";
 import { v4 as uuidv4 } from "uuid";
 
-import { API_URL, db } from "@/config/firebase";
+import { API_URL } from "@/config/firebase";
 import type { ApplicationForm, ApplicationResponse } from "@/types/types";
 
 import { getAppCheckToken } from "./appCheckService";
-
-const APPLICATION_RESPONSES_COLLECTION = "application-responses";
+import { appCollection } from "./firestore";
 
 export async function saveApplicationResponse(
   response: ApplicationResponse,
@@ -50,26 +52,29 @@ export async function saveApplicationResponse(
 export async function getApplicationResponses(
   userId: string,
 ): Promise<ApplicationResponse[]> {
-  const responses = collection(db, APPLICATION_RESPONSES_COLLECTION);
+  const responses = appCollection(FirestoreCollection.ApplicationResponses);
   const q = query(responses, where("userId", "==", userId));
   const results = await getDocs(q);
 
-  return results.docs.map((d) => d.data() as ApplicationResponse);
+  return results.docs.map((d) => d.data());
 }
 
 export async function getApplicationResponseById(
   responseId: string,
 ): Promise<ApplicationResponse | undefined> {
-  const responses = collection(db, APPLICATION_RESPONSES_COLLECTION);
+  const responses = appCollection(FirestoreCollection.ApplicationResponses);
   const respDoc = doc(responses, responseId);
-  return (await getDoc(respDoc)).data() as ApplicationResponse | undefined;
+  const response: ApplicationResponse | undefined = (
+    await getDoc(respDoc)
+  ).data();
+  return response;
 }
 
 async function getApplicationResponseByFormId(
   userId: string,
   formId: string,
 ): Promise<ApplicationResponse | undefined> {
-  const responses = collection(db, APPLICATION_RESPONSES_COLLECTION);
+  const responses = appCollection(FirestoreCollection.ApplicationResponses);
   const q = query(
     responses,
     where("userId", "==", userId),
@@ -82,7 +87,7 @@ async function getApplicationResponseByFormId(
   }
 
   const doc = results.docs[0];
-  const data = doc.data() as ApplicationResponse;
+  const data = doc.data();
 
   return data;
 }
@@ -90,12 +95,12 @@ async function getApplicationResponseByFormId(
 export async function getAllApplicationResponsesByFormId(
   formId: string,
 ): Promise<ApplicationResponse[]> {
-  const responses = collection(db, APPLICATION_RESPONSES_COLLECTION);
+  const responses = appCollection(FirestoreCollection.ApplicationResponses);
   const q = query(responses, where("applicationFormId", "==", formId));
 
   const results = await getDocs(q);
 
-  return results.docs.map((d) => d.data() as ApplicationResponse);
+  return results.docs.map((d) => d.data());
 }
 
 export async function fetchOrCreateApplicationResponse(
@@ -144,11 +149,14 @@ export async function fetchOrCreateApplicationResponse(
   console.log("new response:");
   console.log(newResponse);
 
-  const docRef = doc(db, APPLICATION_RESPONSES_COLLECTION, newResponse.id);
+  const docRef = doc(
+    appCollection(FirestoreCollection.ApplicationResponses),
+    newResponse.id,
+  );
 
   await setDoc(docRef, newResponse);
 
-  const userRef = doc(db, "users", userId);
+  const userRef = doc(appCollection(FirestoreCollection.Users), userId);
   await updateDoc(userRef, {
     activeApplications: arrayUnion(form.id),
   });

--- a/frontend/src/services/autoAssignmentService.ts
+++ b/frontend/src/services/autoAssignmentService.ts
@@ -1,19 +1,21 @@
-import { ApplicantRole, ApplicationStatus } from "@app-portal/shared/constants";
+import {
+  ApplicantRole,
+  ApplicationStatus,
+  FirestoreCollection,
+} from "@app-portal/shared/constants";
 import type {
   AppReviewAssignment,
   ApplicationReviewData,
 } from "@app-portal/shared/types";
-import { collection, doc, writeBatch } from "firebase/firestore";
+import { doc, writeBatch } from "firebase/firestore";
 import { v4 as uuidv4 } from "uuid";
 
 import { db } from "@/config/firebase";
 import type { ReviewCapableUser } from "@/types/types";
 
 import { getAllApplicationResponsesByFormId } from "./applicationResponsesService";
-import {
-  getReviewAssignmentsForForm,
-  REVIEW_ASSIGNMENT_COLLECTION,
-} from "./reviewAssignmentService";
+import { appCollection } from "./firestore";
+import { getReviewAssignmentsForForm } from "./reviewAssignmentService";
 import { getReviewDataForForm } from "./reviewDataService";
 import { getAllReviewers } from "./reviewersService";
 import { getUserById } from "./userService";
@@ -329,7 +331,10 @@ export async function makeAssignmentsFromPlan(plan: AutoAssignmentPlanItem[]) {
     const batch = writeBatch(db);
     chunk.forEach((assignment) =>
       batch.set(
-        doc(collection(db, REVIEW_ASSIGNMENT_COLLECTION), assignment.id),
+        doc(
+          appCollection(FirestoreCollection.ReviewAssignments),
+          assignment.id,
+        ),
         assignment,
       ),
     );

--- a/frontend/src/services/boardService.ts
+++ b/frontend/src/services/boardService.ts
@@ -1,13 +1,14 @@
-import { PermissionRole } from "@app-portal/shared/constants";
+import {
+  FirestoreCollection,
+  PermissionRole,
+} from "@app-portal/shared/constants";
 import type { ApplicantRole } from "@app-portal/shared/constants";
-import { collection, getDocs, query, where } from "firebase/firestore";
+import { getDocs, query, where } from "firebase/firestore";
 
-import { db } from "@/config/firebase";
 import type { BoardUserProfile } from "@/types/types";
 
+import { appCollection } from "./firestore";
 import { getUserById } from "./userService";
-
-const USERS_COLLECTION = "users";
 
 export async function getBoardMemberById(
   id: string,
@@ -36,15 +37,13 @@ export async function getApplicantRolesForBoardMember(
 }
 
 export async function getAllBoardMembers(): Promise<BoardUserProfile[]> {
-  const users = collection(db, USERS_COLLECTION);
+  const users = appCollection(FirestoreCollection.Users);
   const q = query(users, where("role", "==", PermissionRole.Board));
 
   return (await getDocs(q)).docs
     .map((d) => d.data() as BoardUserProfile)
-    .map(
-      (b: BoardUserProfile): BoardUserProfile => ({
-        ...b,
-        applicantRoles: b.applicantRoles ?? [],
-      }),
-    );
+    .map((b) => ({
+      ...b,
+      applicantRoles: b.applicantRoles ?? [],
+    }));
 }

--- a/frontend/src/services/decisionConfirmationService.ts
+++ b/frontend/src/services/decisionConfirmationService.ts
@@ -1,13 +1,12 @@
+import { FirestoreCollection } from "@app-portal/shared/constants";
 import type { DecisionConfirmation } from "@app-portal/shared/types";
 import axios from "axios";
-import type { CollectionReference } from "firebase/firestore";
-import { collection, getDocs, query, where } from "firebase/firestore";
+import { getDocs, query, where } from "firebase/firestore";
 
-import { API_URL, db } from "@/config/firebase";
+import { API_URL } from "@/config/firebase";
 
 import { getAppCheckToken } from "./appCheckService";
-
-const CONFIRMATION_COLLECTION = "decision-status";
+import { appCollection } from "./firestore";
 
 export async function createDecisionConfirmation(
   decisionConfirmation: DecisionConfirmation,
@@ -30,10 +29,9 @@ export async function getDecisionConfirmationForResponseRole(
   userId: string,
   responseId: string,
 ) {
-  const confirmationCollection = collection(
-    db,
-    CONFIRMATION_COLLECTION,
-  ) as CollectionReference<DecisionConfirmation>;
+  const confirmationCollection = appCollection(
+    FirestoreCollection.DecisionStatus,
+  );
   const q = query(
     confirmationCollection,
     where("userId", "==", userId),
@@ -49,10 +47,10 @@ export async function getDecisionConfirmationForResponseRole(
 export async function getAllDecisionConfirmationsByFormId(
   formId: string,
 ): Promise<DecisionConfirmation[]> {
-  const responses = collection(db, CONFIRMATION_COLLECTION);
+  const responses = appCollection(FirestoreCollection.DecisionStatus);
   const q = query(responses, where("formId", "==", formId));
 
   const results = await getDocs(q);
 
-  return results.docs.map((d) => d.data() as DecisionConfirmation);
+  return results.docs.map((d) => d.data());
 }

--- a/frontend/src/services/firestore.ts
+++ b/frontend/src/services/firestore.ts
@@ -1,0 +1,37 @@
+import type { FirestoreCollection } from "@app-portal/shared/constants";
+import type {
+  ApplicationInterviewData,
+  ApplicationReviewData,
+  AppReviewAssignment,
+  DecisionConfirmation,
+  InternalApplicationStatus,
+  InterviewAssignment,
+  RoleReviewRubric,
+} from "@app-portal/shared/types";
+import type { CollectionReference } from "firebase/firestore";
+import { collection } from "firebase/firestore";
+
+import { db } from "@/config/firebase";
+import type {
+  ApplicationForm,
+  ApplicationResponse,
+  UserProfile,
+} from "@/types/types";
+
+type ClientCollectionData = {
+  [FirestoreCollection.Users]: UserProfile;
+  [FirestoreCollection.ApplicationForms]: ApplicationForm;
+  [FirestoreCollection.ApplicationResponses]: ApplicationResponse;
+  [FirestoreCollection.ApplicationStatus]: InternalApplicationStatus;
+  [FirestoreCollection.DecisionStatus]: DecisionConfirmation;
+  [FirestoreCollection.Rubrics]: RoleReviewRubric;
+  [FirestoreCollection.InterviewRubrics]: RoleReviewRubric;
+  [FirestoreCollection.ReviewData]: ApplicationReviewData;
+  [FirestoreCollection.InterviewData]: ApplicationInterviewData;
+  [FirestoreCollection.ReviewAssignments]: AppReviewAssignment;
+  [FirestoreCollection.InterviewAssignments]: InterviewAssignment;
+};
+
+export function appCollection<C extends keyof ClientCollectionData>(name: C) {
+  return collection(db, name) as CollectionReference<ClientCollectionData[C]>;
+}

--- a/frontend/src/services/interviewAssignmentService.ts
+++ b/frontend/src/services/interviewAssignmentService.ts
@@ -1,8 +1,8 @@
+import { FirestoreCollection } from "@app-portal/shared/constants";
 import type { ApplicantRole } from "@app-portal/shared/constants";
 import type { InterviewAssignment } from "@app-portal/shared/types";
 import {
   and,
-  collection,
   deleteDoc,
   doc,
   getDocs,
@@ -12,11 +12,8 @@ import {
 } from "firebase/firestore";
 import { v4 as uuidv4 } from "uuid";
 
-import { db } from "@/config/firebase";
-
 import { getApplicationResponseById } from "./applicationResponsesService";
-
-const INTERVIEW_ASSIGNMENT_COLLECTION = "interview-assignments";
+import { appCollection } from "./firestore";
 
 export async function assignInterview(
   responseId: string,
@@ -40,14 +37,14 @@ export async function assignInterview(
     interviewerId: interviewerId,
   };
 
-  const assignments = collection(db, INTERVIEW_ASSIGNMENT_COLLECTION);
+  const assignments = appCollection(FirestoreCollection.InterviewAssignments);
   await setDoc(doc(assignments, interviewAssignment.id), interviewAssignment);
 
   return interviewAssignment;
 }
 
 export async function removeInterviewAssignment(assignmentId: string) {
-  const assignments = collection(db, INTERVIEW_ASSIGNMENT_COLLECTION);
+  const assignments = appCollection(FirestoreCollection.InterviewAssignments);
   const assignment = doc(assignments, assignmentId);
   await deleteDoc(assignment);
 }
@@ -56,7 +53,7 @@ export async function getInterviewAssignments(
   formId: string,
   interviewerId: string,
 ): Promise<InterviewAssignment[]> {
-  const assignments = collection(db, INTERVIEW_ASSIGNMENT_COLLECTION);
+  const assignments = appCollection(FirestoreCollection.InterviewAssignments);
   const q = query(
     assignments,
     and(
@@ -68,24 +65,24 @@ export async function getInterviewAssignments(
 
   const res = await getDocs(q);
 
-  return res.docs.map((d) => d.data() as InterviewAssignment);
+  return res.docs.map((d) => d.data());
 }
 
 export async function getInterviewAssignmentsForApplication(
   responseId: string,
 ): Promise<InterviewAssignment[]> {
-  const assignments = collection(db, INTERVIEW_ASSIGNMENT_COLLECTION);
+  const assignments = appCollection(FirestoreCollection.InterviewAssignments);
   const q = query(
     assignments,
     where("applicationResponseId", "==", responseId),
   );
 
-  return (await getDocs(q)).docs.map((d) => d.data() as InterviewAssignment);
+  return (await getDocs(q)).docs.map((d) => d.data());
 }
 
 export async function getInterviewAssignmentsForForm(formId: string) {
-  const assignments = collection(db, INTERVIEW_ASSIGNMENT_COLLECTION);
+  const assignments = appCollection(FirestoreCollection.InterviewAssignments);
   const q = query(assignments, where("formId", "==", formId));
 
-  return (await getDocs(q)).docs.map((d) => d.data() as InterviewAssignment);
+  return (await getDocs(q)).docs.map((d) => d.data());
 }

--- a/frontend/src/services/interviewDataService.ts
+++ b/frontend/src/services/interviewDataService.ts
@@ -1,10 +1,10 @@
+import { FirestoreCollection } from "@app-portal/shared/constants";
 import type { ApplicantRole } from "@app-portal/shared/constants";
 import type {
   InterviewAssignment,
   ApplicationInterviewData,
 } from "@app-portal/shared/types";
 import {
-  collection,
   doc,
   getDoc,
   getDocs,
@@ -15,16 +15,14 @@ import {
 } from "firebase/firestore";
 import { v4 as uuidv4 } from "uuid";
 
-import { db } from "@/config/firebase";
-
-const INTERVIEW_DATA_COLLECTION = "interview-data";
+import { appCollection } from "./firestore";
 
 export async function getInterviewDataForResponseRole(
   formId: string,
   responseId: string,
   role: ApplicantRole,
 ) {
-  const interviewData = collection(db, INTERVIEW_DATA_COLLECTION);
+  const interviewData = appCollection(FirestoreCollection.InterviewData);
   const q = query(
     interviewData,
     where("applicationFormId", "==", formId),
@@ -33,11 +31,11 @@ export async function getInterviewDataForResponseRole(
   );
   const result = await getDocs(q);
 
-  return result.docs.map((doc) => doc.data() as ApplicationInterviewData);
+  return result.docs.map((doc) => doc.data());
 }
 
 export async function getInterviewDataById(id: string) {
-  const interviewData = collection(db, INTERVIEW_DATA_COLLECTION);
+  const interviewData = appCollection(FirestoreCollection.InterviewData);
   const docRef = doc(interviewData, id);
 
   return (await getDoc(docRef)).data() as ApplicationInterviewData;
@@ -47,7 +45,7 @@ export async function updateInterviewData(
   interviewDataId: string,
   update: Partial<Omit<ApplicationInterviewData, "id">>,
 ) {
-  const interviewData = collection(db, INTERVIEW_DATA_COLLECTION);
+  const interviewData = appCollection(FirestoreCollection.InterviewData);
   const interviewRef = doc(interviewData, interviewDataId);
 
   await updateDoc(interviewRef, update);
@@ -56,7 +54,7 @@ export async function updateInterviewData(
 export async function getInterviewDataForAssignment(
   assignment: InterviewAssignment,
 ) {
-  const reviewData = collection(db, INTERVIEW_DATA_COLLECTION);
+  const reviewData = appCollection(FirestoreCollection.InterviewData);
   const q = query(
     reviewData,
     where("applicantId", "==", assignment.applicantId),
@@ -68,13 +66,13 @@ export async function getInterviewDataForAssignment(
 
   if (result.docs.length < 1) return undefined;
 
-  return result.docs[0].data() as ApplicationInterviewData;
+  return result.docs[0].data();
 }
 
 export async function createInterviewData(
   review: Omit<ApplicationInterviewData, "id">,
 ) {
-  const reviewData = collection(db, INTERVIEW_DATA_COLLECTION);
+  const reviewData = appCollection(FirestoreCollection.InterviewData);
   const id = uuidv4();
   const reviewDoc: ApplicationInterviewData = {
     id: id,
@@ -88,18 +86,18 @@ export async function createInterviewData(
 }
 
 export async function getInterviewDataForForm(formId: string) {
-  const interviewData = collection(db, INTERVIEW_DATA_COLLECTION);
+  const interviewData = appCollection(FirestoreCollection.InterviewData);
   const q = query(interviewData, where("applicationFormId", "==", formId));
   const result = await getDocs(q);
 
-  return result.docs.map((doc) => doc.data() as ApplicationInterviewData);
+  return result.docs.map((doc) => doc.data());
 }
 
 export async function getInterviewDataForInterviewer(
   formId: string,
   interviewerId: string,
 ) {
-  const interviewData = collection(db, INTERVIEW_DATA_COLLECTION);
+  const interviewData = appCollection(FirestoreCollection.InterviewData);
   const q = query(
     interviewData,
     where("interviewerId", "==", interviewerId),
@@ -107,18 +105,18 @@ export async function getInterviewDataForInterviewer(
   );
   const result = await getDocs(q);
 
-  return result.docs.map((doc) => doc.data() as ApplicationInterviewData);
+  return result.docs.map((doc) => doc.data());
 }
 
 export async function getInterviewDataForResponse(
   applicationResponseId: string,
 ) {
-  const interviewData = collection(db, INTERVIEW_DATA_COLLECTION);
+  const interviewData = appCollection(FirestoreCollection.InterviewData);
   const q = query(
     interviewData,
     where("applicationResponseId", "==", applicationResponseId),
   );
   const result = await getDocs(q);
 
-  return result.docs.map((doc) => doc.data() as ApplicationInterviewData);
+  return result.docs.map((doc) => doc.data());
 }

--- a/frontend/src/services/interviewRubricService.ts
+++ b/frontend/src/services/interviewRubricService.ts
@@ -1,32 +1,32 @@
+import { FirestoreCollection } from "@app-portal/shared/constants";
 import type { ApplicantRole } from "@app-portal/shared/constants";
 import type { RoleReviewRubric } from "@app-portal/shared/types";
 import axios from "axios";
-import { collection, getDocs, query, where } from "firebase/firestore";
+import { getDocs, query, where } from "firebase/firestore";
 
-import { API_URL, db } from "@/config/firebase";
+import { API_URL } from "@/config/firebase";
 
 import { getAppCheckToken } from "./appCheckService";
-
-const INTERVIEW_RUBRIC_COLLECTION = "interview-rubrics";
+import { appCollection } from "./firestore";
 
 export async function getRoleInterviewRubricsForForm(
   formId: string,
 ): Promise<RoleReviewRubric[]> {
-  const interviewRubrics = collection(db, INTERVIEW_RUBRIC_COLLECTION);
+  const interviewRubrics = appCollection(FirestoreCollection.InterviewRubrics);
   const q = query(interviewRubrics, where("formId", "==", formId));
 
-  return (await getDocs(q)).docs.map((d) => d.data() as RoleReviewRubric);
+  return (await getDocs(q)).docs.map((d) => d.data());
 }
 
 export async function getRoleInterviewRubricsForFormRole(
   formId: string,
   role: ApplicantRole,
 ): Promise<RoleReviewRubric[]> {
-  const interviewRubrics = collection(db, INTERVIEW_RUBRIC_COLLECTION);
+  const interviewRubrics = appCollection(FirestoreCollection.InterviewRubrics);
   const q = query(interviewRubrics, where("formId", "==", formId));
 
   return (await getDocs(q)).docs
-    .map((d) => d.data() as RoleReviewRubric)
+    .map((d) => d.data())
     .filter((r) => r.roles.length === 0 || r.roles.includes(role));
 }
 

--- a/frontend/src/services/reviewAssignmentService.ts
+++ b/frontend/src/services/reviewAssignmentService.ts
@@ -1,8 +1,8 @@
+import { FirestoreCollection } from "@app-portal/shared/constants";
 import type { ApplicantRole } from "@app-portal/shared/constants";
 import type { AppReviewAssignment } from "@app-portal/shared/types";
 import {
   and,
-  collection,
   deleteDoc,
   doc,
   getDocs,
@@ -12,11 +12,8 @@ import {
 } from "firebase/firestore";
 import { v4 as uuidv4 } from "uuid";
 
-import { db } from "@/config/firebase";
-
 import { getApplicationResponseById } from "./applicationResponsesService";
-
-export const REVIEW_ASSIGNMENT_COLLECTION = "review-assignments";
+import { appCollection } from "./firestore";
 
 export async function assignReview(
   responseId: string,
@@ -40,14 +37,14 @@ export async function assignReview(
     reviewerId: reviewerId,
   };
 
-  const assignments = collection(db, REVIEW_ASSIGNMENT_COLLECTION);
+  const assignments = appCollection(FirestoreCollection.ReviewAssignments);
   await setDoc(doc(assignments, reviewAssignment.id), reviewAssignment);
 
   return reviewAssignment;
 }
 
 export async function removeReviewAssignment(assignmentId: string) {
-  const assignments = collection(db, REVIEW_ASSIGNMENT_COLLECTION);
+  const assignments = appCollection(FirestoreCollection.ReviewAssignments);
   const assignment = doc(assignments, assignmentId);
   await deleteDoc(assignment);
 }
@@ -56,7 +53,7 @@ export async function getReviewAssignments(
   formId: string,
   reviewerId: string,
 ): Promise<AppReviewAssignment[]> {
-  const assignments = collection(db, REVIEW_ASSIGNMENT_COLLECTION);
+  const assignments = appCollection(FirestoreCollection.ReviewAssignments);
   const q = query(
     assignments,
     and(
@@ -68,24 +65,24 @@ export async function getReviewAssignments(
 
   const res = await getDocs(q);
 
-  return res.docs.map((d) => d.data() as AppReviewAssignment);
+  return res.docs.map((d) => d.data());
 }
 
 export async function getReviewAssignmentsForApplication(
   responseId: string,
 ): Promise<AppReviewAssignment[]> {
-  const assignments = collection(db, REVIEW_ASSIGNMENT_COLLECTION);
+  const assignments = appCollection(FirestoreCollection.ReviewAssignments);
   const q = query(
     assignments,
     where("applicationResponseId", "==", responseId),
   );
 
-  return (await getDocs(q)).docs.map((d) => d.data() as AppReviewAssignment);
+  return (await getDocs(q)).docs.map((d) => d.data());
 }
 
 export async function getReviewAssignmentsForForm(formId: string) {
-  const assignments = collection(db, REVIEW_ASSIGNMENT_COLLECTION);
+  const assignments = appCollection(FirestoreCollection.ReviewAssignments);
   const q = query(assignments, where("formId", "==", formId));
 
-  return (await getDocs(q)).docs.map((d) => d.data() as AppReviewAssignment);
+  return (await getDocs(q)).docs.map((d) => d.data());
 }

--- a/frontend/src/services/reviewDataService.ts
+++ b/frontend/src/services/reviewDataService.ts
@@ -1,10 +1,10 @@
+import { FirestoreCollection } from "@app-portal/shared/constants";
 import type { ApplicantRole } from "@app-portal/shared/constants";
 import type {
   AppReviewAssignment,
   ApplicationReviewData,
 } from "@app-portal/shared/types";
 import {
-  collection,
   doc,
   getDoc,
   getDocs,
@@ -15,12 +15,10 @@ import {
 } from "firebase/firestore";
 import { v4 as uuidv4 } from "uuid";
 
-import { db } from "@/config/firebase";
-
-const REVIEW_DATA_COLLECTION = "review-data";
+import { appCollection } from "./firestore";
 
 export async function getReviewDataById(id: string) {
-  const reviewData = collection(db, REVIEW_DATA_COLLECTION);
+  const reviewData = appCollection(FirestoreCollection.ReviewData);
   const docRef = doc(reviewData, id);
 
   return (await getDoc(docRef)).data() as ApplicationReviewData;
@@ -29,20 +27,20 @@ export async function getReviewDataById(id: string) {
 export async function getReviewDataForApplication(
   applicationResponseId: string,
 ) {
-  const reviewData = collection(db, REVIEW_DATA_COLLECTION);
+  const reviewData = appCollection(FirestoreCollection.ReviewData);
   const q = query(
     reviewData,
     where("applicationResponseId", "==", applicationResponseId),
   );
   const result = await getDocs(q);
 
-  return result.docs.map((doc) => doc.data() as ApplicationReviewData);
+  return result.docs.map((doc) => doc.data());
 }
 
 export async function getReviewDataForAssignment(
   assignment: AppReviewAssignment,
 ) {
-  const reviewData = collection(db, REVIEW_DATA_COLLECTION);
+  const reviewData = appCollection(FirestoreCollection.ReviewData);
   const q = query(
     reviewData,
     where("applicantId", "==", assignment.applicantId),
@@ -54,13 +52,13 @@ export async function getReviewDataForAssignment(
 
   if (result.docs.length < 1) return undefined;
 
-  return result.docs[0].data() as ApplicationReviewData;
+  return result.docs[0].data();
 }
 
 export async function createReviewData(
   review: Omit<ApplicationReviewData, "id">,
 ) {
-  const reviewData = collection(db, REVIEW_DATA_COLLECTION);
+  const reviewData = appCollection(FirestoreCollection.ReviewData);
   const id = uuidv4();
   const reviewDoc: ApplicationReviewData = {
     id: id,
@@ -77,7 +75,7 @@ export async function updateReviewData(
   reviewDataId: string,
   update: Partial<Omit<ApplicationReviewData, "id">>,
 ) {
-  const reviewData = collection(db, REVIEW_DATA_COLLECTION);
+  const reviewData = appCollection(FirestoreCollection.ReviewData);
   const reviewRef = doc(reviewData, reviewDataId);
 
   await updateDoc(reviewRef, update);
@@ -87,7 +85,7 @@ export async function getReviewDataForReviewer(
   formId: string,
   reviewerId: string,
 ) {
-  const reviewData = collection(db, REVIEW_DATA_COLLECTION);
+  const reviewData = appCollection(FirestoreCollection.ReviewData);
   const q = query(
     reviewData,
     where("reviewerId", "==", reviewerId),
@@ -95,7 +93,7 @@ export async function getReviewDataForReviewer(
   );
   const result = await getDocs(q);
 
-  return result.docs.map((doc) => doc.data() as ApplicationReviewData);
+  return result.docs.map((doc) => doc.data());
 }
 
 export async function getReviewDataForResponseRole(
@@ -103,7 +101,7 @@ export async function getReviewDataForResponseRole(
   responseId: string,
   role: ApplicantRole,
 ) {
-  const reviewData = collection(db, REVIEW_DATA_COLLECTION);
+  const reviewData = appCollection(FirestoreCollection.ReviewData);
   const q = query(
     reviewData,
     where("applicationFormId", "==", formId),
@@ -112,13 +110,13 @@ export async function getReviewDataForResponseRole(
   );
   const result = await getDocs(q);
 
-  return result.docs.map((doc) => doc.data() as ApplicationReviewData);
+  return result.docs.map((doc) => doc.data());
 }
 
 export async function getReviewDataForForm(formId: string) {
-  const reviewData = collection(db, REVIEW_DATA_COLLECTION);
+  const reviewData = appCollection(FirestoreCollection.ReviewData);
   const q = query(reviewData, where("applicationFormId", "==", formId));
   const result = await getDocs(q);
 
-  return result.docs.map((doc) => doc.data() as ApplicationReviewData);
+  return result.docs.map((doc) => doc.data());
 }

--- a/frontend/src/services/reviewersService.ts
+++ b/frontend/src/services/reviewersService.ts
@@ -1,12 +1,15 @@
-import { ApplicantRole, PermissionRole } from "@app-portal/shared/constants";
-import { and, collection, getDocs, or, query, where } from "firebase/firestore";
+import {
+  ApplicantRole,
+  FirestoreCollection,
+  PermissionRole,
+} from "@app-portal/shared/constants";
+import { and, getDocs, or, query, where } from "firebase/firestore";
 
-import { db } from "@/config/firebase";
 import type { ReviewCapableUser, UserProfile } from "@/types/types";
 
+import { appCollection } from "./firestore";
 import { getUserById } from "./userService";
 
-const USERS_COLLECTION = "users";
 const REVIEW_CAPABLE_ROLES = [
   PermissionRole.Reviewer,
   PermissionRole.SuperReviewer,
@@ -34,7 +37,7 @@ export async function getRolePreferencesForReviewer(
 }
 
 export async function getAllReviewers(): Promise<ReviewCapableUser[]> {
-  const users = collection(db, USERS_COLLECTION);
+  const users = appCollection(FirestoreCollection.Users);
   const q = query(users, where("role", "in", REVIEW_CAPABLE_ROLES));
 
   // NOTE: for some reason, if the inactive field does not exist, querying on it never matches. we need to filter here instead.
@@ -46,7 +49,7 @@ export async function getAllReviewers(): Promise<ReviewCapableUser[]> {
 export async function getReviewersForRole(
   role: ApplicantRole,
 ): Promise<ReviewCapableUser[]> {
-  const users = collection(db, USERS_COLLECTION);
+  const users = appCollection(FirestoreCollection.Users);
   const q = query(
     users,
     and(

--- a/frontend/src/services/rubricService.ts
+++ b/frontend/src/services/rubricService.ts
@@ -1,14 +1,14 @@
+import { FirestoreCollection } from "@app-portal/shared/constants";
 import type { ApplicantRole } from "@app-portal/shared/constants";
 import type { RoleReviewRubric } from "@app-portal/shared/types";
 import axios from "axios";
-import { collection, getDocs, query, where } from "firebase/firestore";
+import { getDocs, query, where } from "firebase/firestore";
 
-import { API_URL, db } from "@/config/firebase";
+import { API_URL } from "@/config/firebase";
 import type { ApplicationForm } from "@/types/types";
 
 import { getAppCheckToken } from "./appCheckService";
-
-const RUBRIC_COLLECTION = "rubrics";
+import { appCollection } from "./firestore";
 
 export interface RubricValidationWarnings {
   missingInForm: Array<{ role: ApplicantRole; scoreKey: string }>;
@@ -18,21 +18,21 @@ export interface RubricValidationWarnings {
 export async function getRoleRubricsForForm(
   formId: string,
 ): Promise<RoleReviewRubric[]> {
-  const rubrics = collection(db, RUBRIC_COLLECTION);
+  const rubrics = appCollection(FirestoreCollection.Rubrics);
   const q = query(rubrics, where("formId", "==", formId));
 
-  return (await getDocs(q)).docs.map((d) => d.data() as RoleReviewRubric);
+  return (await getDocs(q)).docs.map((d) => d.data());
 }
 
 export async function getRoleRubricsForFormRole(
   formId: string,
   role: ApplicantRole,
 ): Promise<RoleReviewRubric[]> {
-  const rubrics = collection(db, RUBRIC_COLLECTION);
+  const rubrics = appCollection(FirestoreCollection.Rubrics);
   const q = query(rubrics, where("formId", "==", formId));
 
   return (await getDocs(q)).docs
-    .map((d) => d.data() as RoleReviewRubric)
+    .map((d) => d.data())
     .filter((r) => r.roles.length === 0 || r.roles.includes(role));
 }
 

--- a/frontend/src/services/statusService.ts
+++ b/frontend/src/services/statusService.ts
@@ -1,10 +1,11 @@
 import type { ApplicantRole } from "@app-portal/shared/constants";
-import { ReviewStatus } from "@app-portal/shared/constants";
+import {
+  FirestoreCollection,
+  ReviewStatus,
+} from "@app-portal/shared/constants";
 import type { InternalApplicationStatus } from "@app-portal/shared/types";
 import axios from "axios";
-import type { CollectionReference } from "firebase/firestore";
 import {
-  collection,
   doc,
   getDocs,
   query,
@@ -16,8 +17,7 @@ import {
 import { API_URL, db } from "@/config/firebase";
 
 import { getAppCheckToken } from "./appCheckService";
-
-const STATUS_COLLECTION = "app-status";
+import { appCollection } from "./firestore";
 
 export async function getApplicationStatus(
   token: string,
@@ -40,19 +40,16 @@ export async function getApplicationStatus(
 }
 
 export async function getAllApplicationStatusesForForm(formId: string) {
-  const statusCollection = collection(db, STATUS_COLLECTION);
+  const statusCollection = appCollection(FirestoreCollection.ApplicationStatus);
   const q = query(statusCollection, where("formId", "==", formId));
   const docsSnap = await getDocs(q);
-  return docsSnap.docs.map((d) => d.data() as InternalApplicationStatus);
+  return docsSnap.docs.map((d) => d.data());
 }
 
 export async function rejectUndecidedApplicantsForForm(formId: string) {
   const statuses = await getAllApplicationStatusesForForm(formId);
   const undecided = statuses.filter((s) => !isDecided(s.status));
-  const statusCollection = collection(
-    db,
-    STATUS_COLLECTION,
-  ) as CollectionReference<InternalApplicationStatus>;
+  const statusCollection = appCollection(FirestoreCollection.ApplicationStatus);
 
   const chunkSize = 250;
 
@@ -84,10 +81,7 @@ export async function getApplicationStatusForResponseRole(
   responseId: string,
   role: ApplicantRole,
 ) {
-  const statusCollection = collection(
-    db,
-    STATUS_COLLECTION,
-  ) as CollectionReference<InternalApplicationStatus>;
+  const statusCollection = appCollection(FirestoreCollection.ApplicationStatus);
   const q = query(
     statusCollection,
     where("role", "==", role),
@@ -101,10 +95,7 @@ export async function getApplicationStatusForResponseRole(
 }
 
 export async function getApplicationStatusById(statusId: string) {
-  const statusCollection = collection(
-    db,
-    STATUS_COLLECTION,
-  ) as CollectionReference<InternalApplicationStatus>;
+  const statusCollection = appCollection(FirestoreCollection.ApplicationStatus);
   const q = query(statusCollection, where("id", "==", statusId));
 
   const resp = (await getDocs(q)).docs.map((d) => d.data());
@@ -117,10 +108,7 @@ export async function updateApplicationStatus(
   statusId: string,
   update: Partial<Omit<InternalApplicationStatus, "id">>,
 ) {
-  const statusCollection = collection(
-    db,
-    STATUS_COLLECTION,
-  ) as CollectionReference<InternalApplicationStatus>;
+  const statusCollection = appCollection(FirestoreCollection.ApplicationStatus);
   const statusDoc = doc(statusCollection, statusId);
   await updateDoc(statusDoc, update);
 }
@@ -128,14 +116,16 @@ export async function updateApplicationStatus(
 // Helper to fetch all qualified statuses for a form
 export async function getQualifiedStatusesForForm(formId: string) {
   try {
-    const statusCollection = collection(db, STATUS_COLLECTION);
+    const statusCollection = appCollection(
+      FirestoreCollection.ApplicationStatus,
+    );
     const q = query(
       statusCollection,
       where("formId", "==", formId),
       where("isQualified", "==", true),
     );
     const docsSnap = await getDocs(q);
-    return docsSnap.docs.map((d) => d.data() as InternalApplicationStatus);
+    return docsSnap.docs.map((d) => d.data());
   } catch (error) {
     console.error("Failed to fetch qualified statuses:", error);
     throw error;
@@ -148,7 +138,9 @@ export async function getQualifiedStatusesForFormRoles(
 ) {
   if (roles.length === 0) return [];
   try {
-    const statusCollection = collection(db, STATUS_COLLECTION);
+    const statusCollection = appCollection(
+      FirestoreCollection.ApplicationStatus,
+    );
     const q = query(
       statusCollection,
       where("formId", "==", formId),
@@ -156,7 +148,7 @@ export async function getQualifiedStatusesForFormRoles(
       where("role", "in", roles),
     );
     const docsSnap = await getDocs(q);
-    return docsSnap.docs.map((d) => d.data() as InternalApplicationStatus);
+    return docsSnap.docs.map((d) => d.data());
   } catch (error) {
     console.error("Failed to fetch qualified statuses:", error);
     throw error;

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -1,4 +1,8 @@
-import { ApplicantRole, PermissionRole } from "@app-portal/shared/constants";
+import {
+  ApplicantRole,
+  FirestoreCollection,
+  PermissionRole,
+} from "@app-portal/shared/constants";
 import type { SectionResponse } from "@app-portal/shared/types";
 import axios, { AxiosError } from "axios";
 import type { User, UserInfo } from "firebase/auth";
@@ -8,7 +12,6 @@ import {
   signOut,
 } from "firebase/auth";
 import {
-  collection,
   doc,
   getDoc,
   getDocs,
@@ -28,8 +31,7 @@ import type {
 } from "@/types/types";
 
 import { getAppCheckToken } from "./appCheckService";
-
-const USER_COLLECTION = "users";
+import { appCollection } from "./firestore";
 
 export async function sendVerificationEmail(user: User) {
   try {
@@ -142,18 +144,17 @@ export async function logoutUser() {
 }
 
 export async function getUserById(id: string): Promise<UserProfile> {
-  const users = collection(db, USER_COLLECTION);
+  const users = appCollection(FirestoreCollection.Users);
   const userDoc = doc(users, id);
-  const userData = (await getDoc(userDoc)).data();
 
-  return userData as UserProfile;
+  return (await getDoc(userDoc)).data() as UserProfile;
 }
 
 export async function getAllUsers(): Promise<UserProfile[]> {
-  const users = collection(db, USER_COLLECTION);
+  const users = appCollection(FirestoreCollection.Users);
   const results = await getDocs(users);
 
-  return results.docs.map((d) => d.data() as UserProfile);
+  return results.docs.map((d) => d.data());
 }
 
 export async function updateUserRoles(
@@ -161,7 +162,7 @@ export async function updateUserRoles(
   role: PermissionRole,
 ) {
   const batch = writeBatch(db);
-  const usersCollection = collection(db, USER_COLLECTION);
+  const usersCollection = appCollection(FirestoreCollection.Users);
 
   users.forEach((user) => {
     // if the user is being set to a reviewer, update their role preferences
@@ -196,7 +197,7 @@ export async function updateUserActiveStatus(
   userId: string,
   inactive: boolean,
 ) {
-  const users = collection(db, USER_COLLECTION);
+  const users = appCollection(FirestoreCollection.Users);
   const userDoc = doc(users, userId);
   await updateDoc(userDoc, {
     inactive: inactive,
@@ -205,7 +206,7 @@ export async function updateUserActiveStatus(
 
 export async function deleteUsers(userIds: string[]) {
   const batch = writeBatch(db);
-  const users = collection(db, USER_COLLECTION);
+  const users = appCollection(FirestoreCollection.Users);
 
   userIds.forEach((id) => batch.delete(doc(users, id)));
 
@@ -238,7 +239,7 @@ async function setReviewerRolePreferences(
   if (user.role !== PermissionRole.Reviewer)
     throw new Error("User is not a reviewer!");
 
-  const users = collection(db, USER_COLLECTION);
+  const users = appCollection(FirestoreCollection.Users);
   const userDoc = doc(users, reviewerId);
 
   const update: Partial<ReviewerUserProfile> = {
@@ -256,7 +257,7 @@ export async function setBoardApplicantRoles(
   if (user.role !== PermissionRole.Board)
     throw new Error("User is not a board member!");
 
-  const users = collection(db, USER_COLLECTION);
+  const users = appCollection(FirestoreCollection.Users);
   const userDoc = doc(users, boardId);
 
   const update: Partial<BoardUserProfile> = {

--- a/shared/src/constants/index.ts
+++ b/shared/src/constants/index.ts
@@ -1,3 +1,19 @@
+export enum FirestoreCollection {
+  Users = "users",
+  ApplicationForms = "application-forms",
+  ApplicationResponses = "application-responses",
+  ApplicationStatus = "app-status",
+  DecisionStatus = "decision-status",
+  Rubrics = "rubrics",
+  InterviewRubrics = "interview-rubrics",
+  ReviewData = "review-data",
+  InterviewData = "interview-data",
+  ReviewAssignments = "review-assignments",
+  InterviewAssignments = "interview-assignments",
+  GradingJobsPublic = "grading-jobs-public",
+  GradingJobsInternal = "grading-jobs-internal",
+}
+
 export enum PermissionRole {
   SuperReviewer = "super-reviewer",
   Reviewer = "reviewer",


### PR DESCRIPTION
Moves collection names to `shared` to establish single source of truth for collection names. Adds collection name -> type map and collection access helper to frontend + backend ensure all calls are type-safe.
- adds lint rules to ban firestore-related import/property access, ensuring database calls all go through helpers
- addresses all database calls that violate the above

Also removes a lot of nearby/related type assertions.
- backend routes: adds quick log + error throw if assertion was necessary and unsafe and return data is undefined
- frontend: left assertions that would be contractually/semantically different if removed
- any assertions that were unnecessary (alr inferred by typescript) were removed with no additions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal Firestore collection access patterns across backend and frontend services for enhanced type safety and consistency.
  * Established centralized collection reference management to standardize database interactions throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->