### PR TITLE
fix: word count overcounts on whitespace and newlines

### DIFF
--- a/frontend/src/components/form/LongFormInput.tsx
+++ b/frontend/src/components/form/LongFormInput.tsx
@@ -33,7 +33,8 @@ const LongFormInput: React.FC<LongFormInputProps> = ({
   placeholderText = "",
 }) => {
   const wordCount = useMemo(() => {
-    const words = value.trim().split(" ");
+    const trimmedVal = value.trim();
+    const words = trimmedVal.split(/\s+/);
     if (words.length === 1 && words[0] === "") return 0;
     return words.length;
   }, [value]);


### PR DESCRIPTION
Variable wordCount in 'LongFormInput.tsx' was calculated with 'value.trim().split(" ")'. This is an issue as splitting on a single literal space means any consecutive space would count as another entry in the split array, unnecessarily increasing the count. Code is modified to depend on regex expressions where the split handles any length of whitespace rather than a single literal whitespace.

A test file was created and deleted to test this. The results are presented in the attached images
<img width="1448" height="387" alt="TestCodeUsingRegex" src="https://github.com/user-attachments/assets/3e154bb7-e5dd-480c-8df2-7933c838d2aa" />
<img width="611" height="140" alt="TestCodeResults" src="https://github.com/user-attachments/assets/4cd7ad59-73b9-42b6-8318-0d8768ab9be1" />

I appreciate you guys giving me the opportunity to fix this error and I hope it works on your end!

Sincerely,
Karthik Kumar
kkumar07@terpmail.umd.edu


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved word counting in long-form inputs by correctly handling multiple spaces and leading or trailing whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->