### PR TITLE
add copy email

### DIFF
--- a/frontend/src/components/board/BoardApplicationsTable/BoardApplicationsTable.tsx
+++ b/frontend/src/components/board/BoardApplicationsTable/BoardApplicationsTable.tsx
@@ -121,6 +121,31 @@ export default function BoardApplicationsTable({
                     </TooltipContent>
                   </Tooltip>
                 )}
+                <Tooltip>
+                  <TooltipTrigger>
+                    <Button
+                      variant={"outline"}
+                      className="p-0 size-6"
+                      onClick={async () => {
+                        try {
+                          await navigator.clipboard.writeText(
+                            row.original.applicant.email,
+                          );
+                          throwSuccessToast(
+                            `${row.original.applicant.email} added to clipboard!`,
+                          );
+                        } catch (err) {
+                          console.log("Failed to copy email:");
+                          console.log(err);
+                          throwErrorToast(`Failed to add email to clipboard.`);
+                        }
+                      }}
+                    >
+                      <ClipboardIcon className="rounded cursor-pointer text-blue" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Copy Applicant Email</TooltipContent>
+                </Tooltip>
               </span>
             );
           },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a button to copy each applicant’s email address directly from the applications table.
  * Displays confirmation when the email is copied successfully and an error message if copying fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->